### PR TITLE
update psycopg2 2.6.2 -> 2.8.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,7 @@ httplib2==0.10.3
 logutils==0.3.3
 mimeparse==0.1.3
 oauth2==1.9.0.post1
-psycopg2==2.6.2
+psycopg2==2.8.4
 python-dateutil==2.6.0
 social-auth-core==1.7.0
 social-auth-app-django==2.1.0


### PR DESCRIPTION
fix for:
```
ERROR: Command errored out with exit status 1:
     command: /usr/local/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-yv0w7lk5/psycopg2/setup.py'"'"'; __file__='"'"'/tmp/pip-install-yv0w7lk5/psycopg2/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info
         cwd: /tmp/pip-install-yv0w7lk5/psycopg2/
    Complete output (7 lines):
    running egg_info
    creating /tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info/psycopg2.egg-info
    writing /tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing dependency_links to /tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing top-level names to /tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info/psycopg2.egg-info/top_level.txt
    writing manifest file '/tmp/pip-install-yv0w7lk5/psycopg2/pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '11.5'
    ----------------------------------------
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Service 'django-chroniker' failed to build: The command '/bin/sh -c pip install -r /requirements.txt     && groupadd -r django     && useradd -m -r -g django django' returned a non-zero code: 1
```